### PR TITLE
feat: Add course and lesson management to admin sidebar and routes

### DIFF
--- a/src/layout/sidebar/useConfigSidebar.tsx
+++ b/src/layout/sidebar/useConfigSidebar.tsx
@@ -2,6 +2,8 @@
 import DashboardIcon from "@mui/icons-material/Dashboard";
 import EditLocationAltIcon from "@mui/icons-material/EditLocationAlt";
 import MapIcon from "@mui/icons-material/Map";
+import SchoolIcon from "@mui/icons-material/School";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
 import { PATH_ADMIN } from "routes/paths";
 
 function useConfigSidebar() {
@@ -28,6 +30,21 @@ function useConfigSidebar() {
           title: "Quản lý Map",
           path: PATH_ADMIN.mapManagement,
           icon: <MapIcon fontSize="medium" />,
+        },
+      ],
+    },
+    {
+      missions: "Quản lý nội dung",
+      listNav: [
+        {
+          title: "Quản lý Khóa học",
+          path: PATH_ADMIN.courseManagement,
+          icon: <SchoolIcon fontSize="medium" />,
+        },
+        {
+          title: "Quản lý Bài học",
+          path: PATH_ADMIN.lessonManagement,
+          icon: <MenuBookIcon fontSize="medium" />,
         },
       ],
     },

--- a/src/pages/admin/CourseManagementPage.tsx
+++ b/src/pages/admin/CourseManagementPage.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { Box, Container, Typography } from "@mui/material";
+import AdminLayout from "../../layout/admin/AdminLayout";
+import CourseListSection from "../../sections/admin/course/CourseListSection";
+import CourseFormSection from "../../sections/admin/course/CourseFormSection";
+import CourseDetailsSection from "../../sections/admin/course/CourseDetailsSection";
+import { CourseResult } from "../../common/@types/course";
+
+type ViewMode = "list" | "create" | "edit" | "details";
+
+export default function CourseManagementPage() {
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [selectedCourse, setSelectedCourse] = useState<CourseResult | null>(null);
+
+  const handleViewModeChange = (mode: ViewMode, course?: CourseResult) => {
+    setViewMode(mode);
+    setSelectedCourse(course || null);
+  };
+
+  const handleBackToList = () => {
+    setViewMode("list");
+    setSelectedCourse(null);
+  };
+
+  const renderContent = () => {
+    switch (viewMode) {
+      case "create":
+        return (
+          <CourseFormSection
+            mode="create"
+            onBack={handleBackToList}
+            onSuccess={handleBackToList}
+          />
+        );
+      
+      case "edit":
+        return (
+          <CourseFormSection
+            mode="edit"
+            course={selectedCourse}
+            onBack={handleBackToList}
+            onSuccess={handleBackToList}
+          />
+        );
+      
+      case "details":
+        return (
+          <CourseDetailsSection
+            course={selectedCourse}
+            onBack={handleBackToList}
+            onEdit={(course) => handleViewModeChange("edit", course)}
+          />
+        );
+      
+      default:
+        return (
+          <CourseListSection
+            onCreateNew={() => handleViewModeChange("create")}
+            onEditCourse={(course) => handleViewModeChange("edit", course)}
+            onViewDetails={(course) => handleViewModeChange("details", course)}
+          />
+        );
+    }
+  };
+
+  return (
+    <AdminLayout>
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Box sx={{ mb: 4 }}>
+          <Typography
+            variant="h4"
+            component="h1"
+            sx={{
+              fontWeight: 700,
+              color: "#1a1a1a",
+              mb: 1,
+            }}
+          >
+            Quản lý Khóa học
+          </Typography>
+          
+          <Typography
+            variant="body1"
+            sx={{
+              color: "#666",
+            }}
+          >
+            {viewMode === "list" && "Danh sách tất cả khóa học trong hệ thống"}
+            {viewMode === "create" && "Tạo khóa học mới"}
+            {viewMode === "edit" && `Chỉnh sửa khóa học: ${selectedCourse?.title}`}
+            {viewMode === "details" && `Chi tiết khóa học: ${selectedCourse?.title}`}
+          </Typography>
+        </Box>
+
+        {renderContent()}
+      </Container>
+    </AdminLayout>
+  );
+}

--- a/src/pages/admin/LessonManagementPage.tsx
+++ b/src/pages/admin/LessonManagementPage.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { Box, Container, Typography } from "@mui/material";
+import AdminLayout from "../../layout/admin/AdminLayout";
+import LessonListSection from "../../sections/admin/lesson/LessonListSection";
+import LessonFormSection from "../../sections/admin/lesson/LessonFormSection";
+import LessonDetailsSection from "../../sections/admin/lesson/LessonDetailsSection";
+import { LessonResult } from "../../common/@types/lesson";
+
+type ViewMode = "list" | "create" | "edit" | "details";
+
+export default function LessonManagementPage() {
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [selectedLesson, setSelectedLesson] = useState<LessonResult | null>(null);
+  const [selectedCourseId, setSelectedCourseId] = useState<string>("");
+
+  const handleViewModeChange = (mode: ViewMode, lesson?: LessonResult, courseId?: string) => {
+    setViewMode(mode);
+    setSelectedLesson(lesson || null);
+    if (courseId) setSelectedCourseId(courseId);
+  };
+
+  const handleBackToList = () => {
+    setViewMode("list");
+    setSelectedLesson(null);
+    setSelectedCourseId("");
+  };
+
+  const renderContent = () => {
+    switch (viewMode) {
+      case "create":
+        return (
+          <LessonFormSection
+            mode="create"
+            courseId={selectedCourseId}
+            onBack={handleBackToList}
+            onSuccess={handleBackToList}
+          />
+        );
+      
+      case "edit":
+        return (
+          <LessonFormSection
+            mode="edit"
+            lesson={selectedLesson}
+            onBack={handleBackToList}
+            onSuccess={handleBackToList}
+          />
+        );
+      
+      case "details":
+        return (
+          <LessonDetailsSection
+            lesson={selectedLesson}
+            onBack={handleBackToList}
+            onEdit={(lesson) => handleViewModeChange("edit", lesson)}
+          />
+        );
+      
+      default:
+        return (
+          <LessonListSection
+            onCreateNew={(courseId) => handleViewModeChange("create", undefined, courseId)}
+            onEditLesson={(lesson) => handleViewModeChange("edit", lesson)}
+            onViewDetails={(lesson) => handleViewModeChange("details", lesson)}
+          />
+        );
+    }
+  };
+
+  return (
+    <AdminLayout>
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        <Box sx={{ mb: 4 }}>
+          <Typography
+            variant="h4"
+            component="h1"
+            sx={{
+              fontWeight: 700,
+              color: "#1a1a1a",
+              mb: 1,
+            }}
+          >
+            Quản lý Bài học
+          </Typography>
+          
+          <Typography
+            variant="body1"
+            sx={{
+              color: "#666",
+            }}
+          >
+            {viewMode === "list" && "Danh sách tất cả bài học trong hệ thống"}
+            {viewMode === "create" && "Tạo bài học mới"}
+            {viewMode === "edit" && `Chỉnh sửa bài học: ${selectedLesson?.title}`}
+            {viewMode === "details" && `Chi tiết bài học: ${selectedLesson?.title}`}
+          </Typography>
+        </Box>
+
+        {renderContent()}
+      </Container>
+    </AdminLayout>
+  );
+}

--- a/src/routes/config/adminRoutes.tsx
+++ b/src/routes/config/adminRoutes.tsx
@@ -6,6 +6,8 @@ import { PATH_ADMIN } from "routes/paths";
 // Lazy load admin pages
 const MapDesignerPage = lazy(() => import("pages/admin/MapDesignerPage"));
 const MapManagementPage = lazy(() => import("pages/admin/MapManagementPage"));
+const CourseManagementPage = lazy(() => import("pages/admin/CourseManagementPage"));
+const LessonManagementPage = lazy(() => import("pages/admin/LessonManagementPage"));
 const AdminTestPage = lazy(() => import("pages/admin/AdminTestPage"));
 
 export const adminRoutes: Route[] = [
@@ -22,6 +24,16 @@ export const adminRoutes: Route[] = [
   {
     path: PATH_ADMIN.mapManagement,
     component: <MapManagementPage />,
+    index: false,
+  },
+  {
+    path: PATH_ADMIN.courseManagement,
+    component: <CourseManagementPage />,
+    index: false,
+  },
+  {
+    path: PATH_ADMIN.lessonManagement,
+    component: <LessonManagementPage />,
     index: false,
   },
   {

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -42,4 +42,6 @@ export const PATH_ADMIN = {
   dashboard: path(ROOTS_ADMIN_DASHBOARD, "/dashboard"),
   mapDesigner: path(ROOTS_ADMIN_DASHBOARD, "/map-designer"),
   mapManagement: path(ROOTS_ADMIN_DASHBOARD, "/map-management"),
+  courseManagement: path(ROOTS_ADMIN_DASHBOARD, "/course-management"),
+  lessonManagement: path(ROOTS_ADMIN_DASHBOARD, "/lesson-management"),
 };

--- a/src/sections/admin/course/CourseDetailsSection.tsx
+++ b/src/sections/admin/course/CourseDetailsSection.tsx
@@ -1,0 +1,297 @@
+import { useEffect } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Grid,
+  Stack,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Avatar,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EditIcon from "@mui/icons-material/Edit";
+import MenuBookIcon from "@mui/icons-material/MenuBook";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import GroupIcon from "@mui/icons-material/Group";
+import { useAppDispatch, useAppSelector } from "../../../redux/config";
+import { getLessonsByCourse } from "../../../redux/lesson/lessonSlice";
+import { CourseResult } from "../../../common/@types/course";
+
+interface Props {
+  course: CourseResult | null;
+  onBack: () => void;
+  onEdit: (course: CourseResult) => void;
+}
+
+export default function CourseDetailsSection({ course, onBack, onEdit }: Props) {
+  const dispatch = useAppDispatch();
+  const { data: courseLessons, isLoading: lessonsLoading } = useAppSelector((s) => s.lesson.courseLessons);
+
+  useEffect(() => {
+    if (course?.id) {
+      dispatch(getLessonsByCourse({ courseId: course.id }));
+    }
+  }, [dispatch, course?.id]);
+
+  if (!course) {
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography>Không tìm thấy thông tin khóa học</Typography>
+        <Button onClick={onBack} sx={{ mt: 2 }}>
+          Quay lại
+        </Button>
+      </Box>
+    );
+  }
+
+  const lessons = courseLessons?.items || [];
+  const totalDuration = lessons.reduce((sum, lesson) => sum + lesson.durationInMinutes, 0);
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+          Quay lại
+        </Button>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          Chi tiết khóa học
+        </Typography>
+      </Stack>
+
+      <Grid container spacing={3}>
+        {/* Course Info */}
+        <Grid item xs={12} lg={8}>
+          <Card sx={{ mb: 3 }}>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 3 }}>
+                <Box sx={{ flex: 1 }}>
+                  <Typography variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
+                    {course.title}
+                  </Typography>
+                  <Typography variant="body1" sx={{ mb: 3, lineHeight: 1.7 }}>
+                    {course.description}
+                  </Typography>
+                  
+                  <Stack direction="row" spacing={3} flexWrap="wrap">
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <MenuBookIcon color="primary" fontSize="small" />
+                      <Typography variant="body2">
+                        {lessons.length} bài học
+                      </Typography>
+                    </Stack>
+                    
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <AccessTimeIcon color="primary" fontSize="small" />
+                      <Typography variant="body2">
+                        {Math.floor(totalDuration / 60)}h {totalDuration % 60}m
+                      </Typography>
+                    </Stack>
+                    
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <GroupIcon color="primary" fontSize="small" />
+                      <Typography variant="body2">
+                        {course.enrollmentsCount || 0} học viên
+                      </Typography>
+                    </Stack>
+                  </Stack>
+                </Box>
+                
+                <Button
+                  variant="contained"
+                  startIcon={<EditIcon />}
+                  onClick={() => onEdit(course)}
+                  sx={{ ml: 2 }}
+                >
+                  Chỉnh sửa
+                </Button>
+              </Stack>
+
+              {course.imageUrl && (
+                <Box sx={{ mb: 3 }}>
+                  <img
+                    src={course.imageUrl}
+                    alt={course.title}
+                    style={{
+                      width: "100%",
+                      maxHeight: "300px",
+                      objectFit: "cover",
+                      borderRadius: "12px",
+                    }}
+                  />
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Lessons List */}
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+                <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                  Danh sách bài học
+                </Typography>
+                <Chip
+                  label={`${lessons.length} bài học`}
+                  color="primary"
+                  variant="outlined"
+                />
+              </Stack>
+
+              {lessonsLoading ? (
+                <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+                  <CircularProgress />
+                </Box>
+              ) : lessons.length === 0 ? (
+                <Box sx={{ textAlign: "center", py: 4 }}>
+                  <MenuBookIcon sx={{ fontSize: 64, color: "text.disabled", mb: 2 }} />
+                  <Typography variant="h6" color="text.secondary">
+                    Chưa có bài học nào
+                  </Typography>
+                  <Typography variant="body2" color="text.disabled">
+                    Thêm bài học đầu tiên cho khóa học này
+                  </Typography>
+                </Box>
+              ) : (
+                <TableContainer component={Paper} variant="outlined">
+                  <Table>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Thứ tự</TableCell>
+                        <TableCell>Tên bài học</TableCell>
+                        <TableCell>Thời lượng</TableCell>
+                        <TableCell>Ngày tạo</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {lessons
+                        .sort((a, b) => a.order - b.order)
+                        .map((lesson) => (
+                          <TableRow key={lesson.id} hover>
+                            <TableCell>
+                              <Chip
+                                label={lesson.order}
+                                size="small"
+                                color="primary"
+                                variant="outlined"
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                                {lesson.title}
+                              </Typography>
+                              {lesson.content && (
+                                <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                                  {lesson.content.length > 100
+                                    ? `${lesson.content.substring(0, 100)}...`
+                                    : lesson.content}
+                                </Typography>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <Stack direction="row" alignItems="center" spacing={1}>
+                                <AccessTimeIcon fontSize="small" color="action" />
+                                <Typography variant="body2">
+                                  {lesson.durationInMinutes} phút
+                                </Typography>
+                              </Stack>
+                            </TableCell>
+                            <TableCell>
+                              <Typography variant="body2">
+                                {new Date(lesson.createdAt).toLocaleDateString("vi-VN")}
+                              </Typography>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Course Stats */}
+        <Grid item xs={12} lg={4}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 3 }}>
+                Thông tin khóa học
+              </Typography>
+
+              <Stack spacing={3}>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Người tạo
+                  </Typography>
+                  <Stack direction="row" alignItems="center" spacing={2}>
+                    <Avatar sx={{ bgcolor: "primary.main" }}>
+                      {course.createdByName?.charAt(0) || "?"}
+                    </Avatar>
+                    <Typography variant="subtitle2">
+                      {course.createdByName || "Không xác định"}
+                    </Typography>
+                  </Stack>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Ngày tạo
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {new Date(course.createdAt).toLocaleDateString("vi-VN", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Cập nhật lần cuối
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {new Date(course.updatedAt).toLocaleDateString("vi-VN", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Trạng thái
+                  </Typography>
+                  <Chip
+                    label="Đang hoạt động"
+                    color="success"
+                    size="small"
+                    variant="outlined"
+                  />
+                </Box>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/sections/admin/course/CourseFormSection.tsx
+++ b/src/sections/admin/course/CourseFormSection.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Grid,
+  Snackbar,
+  Alert,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import SaveIcon from "@mui/icons-material/Save";
+import { useAppDispatch, useAppSelector } from "../../../redux/config";
+import { createCourse, updateCourse } from "../../../redux/course/courseSlice";
+import { CourseResult, CreateCourseRequest, UpdateCourseRequest } from "../../../common/@types/course";
+
+interface Props {
+  mode: "create" | "edit";
+  course?: CourseResult | null;
+  onBack: () => void;
+  onSuccess: () => void;
+}
+
+interface FormData {
+  title: string;
+  description: string;
+  imageUrl: string;
+}
+
+export default function CourseFormSection({ mode, course, onBack, onSuccess }: Props) {
+  const dispatch = useAppDispatch();
+  const { isCreating, isUpdating, createError, updateError } = useAppSelector((s) => s.course.operations);
+
+  const [formData, setFormData] = useState<FormData>({
+    title: "",
+    description: "",
+    imageUrl: "",
+  });
+
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({ 
+    open: false, 
+    message: "", 
+    severity: "success" 
+  });
+
+  const isLoading = isCreating || isUpdating;
+  const error = createError || updateError;
+
+  useEffect(() => {
+    if (mode === "edit" && course) {
+      setFormData({
+        title: course.title,
+        description: course.description,
+        imageUrl: course.imageUrl || "",
+      });
+    }
+  }, [mode, course]);
+
+  const handleInputChange = (field: keyof FormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const validate = (): boolean => {
+    if (!formData.title.trim()) {
+      setSnackbar({ open: true, message: "Tên khóa học không được để trống", severity: "error" });
+      return false;
+    }
+    if (!formData.description.trim()) {
+      setSnackbar({ open: true, message: "Mô tả khóa học không được để trống", severity: "error" });
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    try {
+      if (mode === "create") {
+        const createData: CreateCourseRequest = {
+          title: formData.title.trim(),
+          description: formData.description.trim(),
+          imageUrl: formData.imageUrl.trim() || undefined,
+        };
+        await dispatch(createCourse(createData)).unwrap();
+        setSnackbar({ open: true, message: "Tạo khóa học thành công", severity: "success" });
+      } else if (course) {
+        const updateData: UpdateCourseRequest = {
+          title: formData.title.trim(),
+          description: formData.description.trim(),
+          imageUrl: formData.imageUrl.trim() || undefined,
+        };
+        await dispatch(updateCourse({ id: course.id, data: updateData })).unwrap();
+        setSnackbar({ open: true, message: "Cập nhật khóa học thành công", severity: "success" });
+      }
+      
+      setTimeout(() => {
+        onSuccess();
+      }, 1000);
+    } catch (err: any) {
+      setSnackbar({ open: true, message: err?.message || "Có lỗi xảy ra", severity: "error" });
+    }
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+          Quay lại
+        </Button>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          {mode === "create" ? "Tạo khóa học mới" : "Chỉnh sửa khóa học"}
+        </Typography>
+      </Stack>
+
+      <Card>
+        <CardContent>
+          <Box component="form" onSubmit={handleSubmit}>
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={8}>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Thông tin cơ bản
+                </Typography>
+                
+                <Stack spacing={3}>
+                  <TextField
+                    fullWidth
+                    label="Tên khóa học *"
+                    value={formData.title}
+                    onChange={handleInputChange("title")}
+                    error={!!error && error.includes("title")}
+                    helperText="Nhập tên khóa học dễ hiểu và thu hút"
+                  />
+
+                  <TextField
+                    fullWidth
+                    label="Mô tả *"
+                    value={formData.description}
+                    onChange={handleInputChange("description")}
+                    multiline
+                    rows={4}
+                    error={!!error && error.includes("description")}
+                    helperText="Mô tả chi tiết về khóa học, mục tiêu học tập"
+                  />
+
+                  <TextField
+                    fullWidth
+                    label="URL Hình ảnh"
+                    value={formData.imageUrl}
+                    onChange={handleInputChange("imageUrl")}
+                    placeholder="https://example.com/image.jpg"
+                    helperText="Link hình đại diện cho khóa học (tùy chọn)"
+                  />
+                </Stack>
+              </Grid>
+
+              <Grid item xs={12} md={4}>
+                <Typography variant="h6" sx={{ mb: 2 }}>
+                  Xem trước
+                </Typography>
+                
+                <Card variant="outlined">
+                  <CardContent>
+                    {formData.imageUrl && (
+                      <Box sx={{ mb: 2 }}>
+                        <img
+                          src={formData.imageUrl}
+                          alt="Preview"
+                          style={{
+                            width: "100%",
+                            height: "120px",
+                            objectFit: "cover",
+                            borderRadius: "8px",
+                          }}
+                          onError={(e) => {
+                            e.currentTarget.style.display = "none";
+                          }}
+                        />
+                      </Box>
+                    )}
+                    
+                    <Typography variant="h6" sx={{ mb: 1 }}>
+                      {formData.title || "Tên khóa học"}
+                    </Typography>
+                    
+                    <Typography variant="body2" color="text.secondary">
+                      {formData.description || "Mô tả khóa học sẽ hiển thị ở đây"}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
+
+            <Box sx={{ mt: 4, display: "flex", gap: 2, justifyContent: "flex-end" }}>
+              <Button variant="outlined" onClick={onBack} disabled={isLoading}>
+                Hủy
+              </Button>
+              <Button
+                type="submit"
+                variant="contained"
+                startIcon={isLoading ? <CircularProgress size={16} /> : <SaveIcon />}
+                disabled={isLoading}
+              >
+                {mode === "create" ? "Tạo khóa học" : "Cập nhật"}
+              </Button>
+            </Box>
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Snackbar 
+        open={snackbar.open} 
+        autoHideDuration={4000} 
+        onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+      >
+        <Alert severity={snackbar.severity} sx={{ width: "100%" }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/src/sections/admin/course/CourseListSection.tsx
+++ b/src/sections/admin/course/CourseListSection.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  IconButton,
+  Pagination,
+  Snackbar,
+  Alert,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import { useAppDispatch, useAppSelector } from "../../../redux/config";
+import { getCourses, deleteCourse } from "../../../redux/course/courseSlice";
+import { CourseResult } from "../../../common/@types/course";
+
+interface Props {
+  onCreateNew: () => void;
+  onEditCourse: (course: CourseResult) => void;
+  onViewDetails: (course: CourseResult) => void;
+}
+
+export default function CourseListSection({
+  onCreateNew,
+  onEditCourse,
+  onViewDetails,
+}: Props) {
+  const dispatch = useAppDispatch();
+  const { data, isLoading, error } = useAppSelector((s) => s.course.courses);
+
+  const [query, setQuery] = useState({
+    pageNumber: 1,
+    pageSize: 12,
+    searchTerm: "",
+  });
+  const [confirmDelete, setConfirmDelete] = useState<CourseResult | null>(null);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
+  }>({ open: false, message: "", severity: "success" });
+
+  useEffect(() => {
+    dispatch(getCourses(query as any));
+  }, [dispatch, query.pageNumber, query.pageSize, query.searchTerm]);
+
+  const items = data?.items || [];
+  const totalPages = data?.totalPages || 1;
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    try {
+      await dispatch(deleteCourse(confirmDelete.id)).unwrap();
+      setSnackbar({
+        open: true,
+        message: "Xóa khóa học thành công",
+        severity: "success",
+      });
+    } catch (e: any) {
+      setSnackbar({
+        open: true,
+        message: e?.message || "Không thể xóa khóa học",
+        severity: "error",
+      });
+    } finally {
+      setConfirmDelete(null);
+    }
+  };
+
+  return (
+    <Box>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        spacing={2}
+        alignItems={{ xs: "stretch", sm: "center" }}
+        justifyContent="space-between"
+        sx={{ mb: 2 }}
+      >
+        <TextField
+          size="small"
+          placeholder="Tìm kiếm khóa học..."
+          value={query.searchTerm}
+          onChange={(e) =>
+            setQuery((q) => ({
+              ...q,
+              searchTerm: e.target.value,
+              pageNumber: 1,
+            }))
+          }
+          sx={{ maxWidth: 360 }}
+        />
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={onCreateNew}
+        >
+          Tạo khóa học
+        </Button>
+      </Stack>
+
+      {isLoading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Alert severity="error">{error}</Alert>
+      ) : items.length === 0 ? (
+        <Alert severity="info">Chưa có khóa học nào</Alert>
+      ) : (
+        <Grid container spacing={2}>
+          {items.map((course) => (
+            <Grid item xs={12} md={6} lg={4} key={course.id}>
+              <Card
+                sx={{
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <CardContent sx={{ flex: 1 }}>
+                  <Typography variant="h6" sx={{ mb: 1 }}>
+                    {course.title}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mb: 2 }}
+                  >
+                    {course.description}
+                  </Typography>
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<VisibilityIcon />}
+                      onClick={() => onViewDetails(course)}
+                    >
+                      Chi tiết
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="contained"
+                      startIcon={<EditIcon />}
+                      onClick={() => onEditCourse(course)}
+                    >
+                      Sửa
+                    </Button>
+                    <IconButton
+                      color="error"
+                      onClick={() => setConfirmDelete(course)}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Stack>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {totalPages > 1 && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 3 }}>
+          <Pagination
+            count={totalPages}
+            page={query.pageNumber}
+            onChange={(_, p) => setQuery((q) => ({ ...q, pageNumber: p }))}
+            color="primary"
+          />
+        </Box>
+      )}
+
+      <Dialog open={!!confirmDelete} onClose={() => setConfirmDelete(null)}>
+        <DialogTitle>Xác nhận xóa</DialogTitle>
+        <DialogContent>
+          Bạn có chắc muốn xóa khóa học "{confirmDelete?.title}"?
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDelete(null)}>Hủy</Button>
+          <Button color="error" onClick={handleDelete}>
+            Xóa
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+      >
+        <Alert severity={snackbar.severity} sx={{ width: "100%" }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/src/sections/admin/lesson/LessonDetailsSection.tsx
+++ b/src/sections/admin/lesson/LessonDetailsSection.tsx
@@ -1,0 +1,277 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EditIcon from "@mui/icons-material/Edit";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import SchoolIcon from "@mui/icons-material/School";
+import { LessonResult } from "../../../common/@types/lesson";
+
+interface Props {
+  lesson: LessonResult | null;
+  onBack: () => void;
+  onEdit: (lesson: LessonResult) => void;
+}
+
+export default function LessonDetailsSection({ lesson, onBack, onEdit }: Props) {
+  if (!lesson) {
+    return (
+      <Box sx={{ textAlign: "center", py: 4 }}>
+        <Typography>Không tìm thấy thông tin bài học</Typography>
+        <Button onClick={onBack} sx={{ mt: 2 }}>
+          Quay lại
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+          Quay lại
+        </Button>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          Chi tiết bài học
+        </Typography>
+      </Stack>
+
+      <Grid container spacing={3}>
+        {/* Lesson Content */}
+        <Grid item xs={12} lg={8}>
+          <Card sx={{ mb: 3 }}>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 3 }}>
+                <Box sx={{ flex: 1 }}>
+                  <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+                    <Chip
+                      label={`Bài ${lesson.order}`}
+                      color="primary"
+                      variant="outlined"
+                    />
+                    <Chip
+                      label={lesson.courseTitle || "Không xác định"}
+                      variant="outlined"
+                    />
+                  </Stack>
+                  
+                  <Typography variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
+                    {lesson.title}
+                  </Typography>
+                  
+                  <Stack direction="row" alignItems="center" spacing={3} sx={{ mb: 3 }}>
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <AccessTimeIcon color="primary" fontSize="small" />
+                      <Typography variant="body2">
+                        {lesson.durationInMinutes} phút
+                      </Typography>
+                    </Stack>
+                    
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <SchoolIcon color="primary" fontSize="small" />
+                      <Typography variant="body2">
+                        {lesson.challengesCount || 0} thử thách
+                      </Typography>
+                    </Stack>
+                  </Stack>
+                </Box>
+                
+                <Button
+                  variant="contained"
+                  startIcon={<EditIcon />}
+                  onClick={() => onEdit(lesson)}
+                  sx={{ ml: 2 }}
+                >
+                  Chỉnh sửa
+                </Button>
+              </Stack>
+
+              <Divider sx={{ mb: 3 }} />
+
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+                Nội dung bài học
+              </Typography>
+              
+              <Box sx={{ 
+                p: 3, 
+                backgroundColor: "#f8f9fa", 
+                borderRadius: 2,
+                border: "1px solid #e0e0e0"
+              }}>
+                <Typography variant="body1" sx={{ 
+                  lineHeight: 1.8,
+                  whiteSpace: "pre-wrap"
+                }}>
+                  {lesson.content}
+                </Typography>
+              </Box>
+            </CardContent>
+          </Card>
+
+          {/* Challenges Section */}
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+                <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                  Thử thách
+                </Typography>
+                <Chip
+                  label={`${lesson.challengesCount || 0} thử thách`}
+                  color="primary"
+                  variant="outlined"
+                />
+              </Stack>
+
+              {lesson.challenges && lesson.challenges.length > 0 ? (
+                <Grid container spacing={2}>
+                  {lesson.challenges.map((challenge, index) => (
+                    <Grid item xs={12} md={6} key={challenge.id}>
+                      <Card variant="outlined">
+                        <CardContent>
+                          <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
+                            <Chip
+                              label={`#${index + 1}`}
+                              size="small"
+                              color="primary"
+                            />
+                            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                              {challenge.title}
+                            </Typography>
+                          </Stack>
+                          
+                          <Typography variant="body2" color="text.secondary">
+                            {challenge.description && challenge.description.length > 100 
+                              ? `${challenge.description.substring(0, 100)}...`
+                              : challenge.description || "Không có mô tả"
+                            }
+                          </Typography>
+                        </CardContent>
+                      </Card>
+                    </Grid>
+                  ))}
+                </Grid>
+              ) : (
+                <Box sx={{ textAlign: "center", py: 4 }}>
+                  <SchoolIcon sx={{ fontSize: 64, color: "text.disabled", mb: 2 }} />
+                  <Typography variant="h6" color="text.secondary">
+                    Chưa có thử thách nào
+                  </Typography>
+                  <Typography variant="body2" color="text.disabled">
+                    Thêm thử thách để học viên có thể thực hành
+                  </Typography>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Lesson Info Sidebar */}
+        <Grid item xs={12} lg={4}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" sx={{ fontWeight: 600, mb: 3 }}>
+                Thông tin bài học
+              </Typography>
+
+              <Stack spacing={3}>
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Khóa học
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {lesson.courseTitle || "Không xác định"}
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Thời lượng
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {lesson.durationInMinutes} phút
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Thứ tự
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    Bài {lesson.order}
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Số thử thách
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {lesson.challengesCount || 0} thử thách
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Ngày tạo
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {new Date(lesson.createdAt).toLocaleDateString("vi-VN", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Cập nhật lần cuối
+                  </Typography>
+                  <Typography variant="subtitle2">
+                    {new Date(lesson.updatedAt).toLocaleDateString("vi-VN", {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    })}
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Box>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    Trạng thái
+                  </Typography>
+                  <Chip
+                    label="Đang hoạt động"
+                    color="success"
+                    size="small"
+                    variant="outlined"
+                  />
+                </Box>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/sections/admin/lesson/LessonFormSection.tsx
+++ b/src/sections/admin/lesson/LessonFormSection.tsx
@@ -1,0 +1,316 @@
+import React, { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Grid,
+  Snackbar,
+  Alert,
+  Stack,
+  TextField,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Slider,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import SaveIcon from "@mui/icons-material/Save";
+import { useAppDispatch, useAppSelector } from "../../../redux/config";
+import { createLesson, updateLesson } from "../../../redux/lesson/lessonSlice";
+import { getCourses } from "../../../redux/course/courseSlice";
+import { LessonResult, CreateLessonRequest, UpdateLessonRequest } from "../../../common/@types/lesson";
+
+interface Props {
+  mode: "create" | "edit";
+  lesson?: LessonResult | null;
+  courseId?: string;
+  onBack: () => void;
+  onSuccess: () => void;
+}
+
+interface FormData {
+  courseId: string;
+  title: string;
+  content: string;
+  durationInMinutes: number;
+  order: number;
+}
+
+export default function LessonFormSection({ mode, lesson, courseId = "", onBack, onSuccess }: Props) {
+  const dispatch = useAppDispatch();
+  const { isCreating, isUpdating, createError, updateError } = useAppSelector((s) => s.lesson.operations);
+  const { data: coursesData } = useAppSelector((s) => s.course.courses);
+
+  const [formData, setFormData] = useState<FormData>({
+    courseId: courseId,
+    title: "",
+    content: "",
+    durationInMinutes: 30,
+    order: 1,
+  });
+
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({ 
+    open: false, 
+    message: "", 
+    severity: "success" 
+  });
+
+  const isLoading = isCreating || isUpdating;
+  const error = createError || updateError;
+  const courses = coursesData?.items || [];
+
+  useEffect(() => {
+    dispatch(getCourses({ pageSize: 100 } as any));
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (mode === "edit" && lesson) {
+      setFormData({
+        courseId: lesson.courseId,
+        title: lesson.title,
+        content: lesson.content,
+        durationInMinutes: lesson.durationInMinutes,
+        order: lesson.order,
+      });
+    }
+  }, [mode, lesson]);
+
+  const handleInputChange = (field: keyof FormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleSelectChange = (field: keyof FormData) => (e: any) => {
+    setFormData(prev => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleDurationChange = (_: Event, value: number | number[]) => {
+    setFormData(prev => ({ ...prev, durationInMinutes: value as number }));
+  };
+
+  const validate = (): boolean => {
+    if (!formData.courseId) {
+      setSnackbar({ open: true, message: "Vui lòng chọn khóa học", severity: "error" });
+      return false;
+    }
+    if (!formData.title.trim()) {
+      setSnackbar({ open: true, message: "Tên bài học không được để trống", severity: "error" });
+      return false;
+    }
+    if (!formData.content.trim()) {
+      setSnackbar({ open: true, message: "Nội dung bài học không được để trống", severity: "error" });
+      return false;
+    }
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    try {
+      if (mode === "create") {
+        const createData: CreateLessonRequest = {
+          courseId: formData.courseId,
+          title: formData.title.trim(),
+          content: formData.content.trim(),
+          durationInMinutes: formData.durationInMinutes,
+          order: formData.order,
+        };
+        await dispatch(createLesson(createData)).unwrap();
+        setSnackbar({ open: true, message: "Tạo bài học thành công", severity: "success" });
+      } else if (lesson) {
+        const updateData: UpdateLessonRequest = {
+          courseId: formData.courseId,
+          title: formData.title.trim(),
+          content: formData.content.trim(),
+          durationInMinutes: formData.durationInMinutes,
+          order: formData.order,
+        };
+        await dispatch(updateLesson({ id: lesson.id, data: updateData })).unwrap();
+        setSnackbar({ open: true, message: "Cập nhật bài học thành công", severity: "success" });
+      }
+      
+      setTimeout(() => {
+        onSuccess();
+      }, 1000);
+    } catch (err: any) {
+      setSnackbar({ open: true, message: err?.message || "Có lỗi xảy ra", severity: "error" });
+    }
+  };
+
+  const selectedCourse = courses.find(c => c.id === formData.courseId);
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+          Quay lại
+        </Button>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          {mode === "create" ? "Tạo bài học mới" : "Chỉnh sửa bài học"}
+        </Typography>
+      </Stack>
+
+      <Card>
+        <CardContent>
+          <Box component="form" onSubmit={handleSubmit}>
+            <Grid container spacing={3}>
+              <Grid item xs={12} md={8}>
+                <Typography variant="h6" sx={{ mb: 3 }}>
+                  Thông tin bài học
+                </Typography>
+                
+                <Stack spacing={3}>
+                  <FormControl fullWidth>
+                    <InputLabel>Khóa học *</InputLabel>
+                    <Select
+                      value={formData.courseId}
+                      label="Khóa học *"
+                      onChange={handleSelectChange("courseId")}
+                      error={!!error && error.includes("courseId")}
+                    >
+                      {courses.map((course) => (
+                        <MenuItem key={course.id} value={course.id}>
+                          {course.title}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+
+                  <TextField
+                    fullWidth
+                    label="Tên bài học *"
+                    value={formData.title}
+                    onChange={handleInputChange("title")}
+                    error={!!error && error.includes("title")}
+                    helperText="Nhập tên bài học rõ ràng và dễ hiểu"
+                  />
+
+                  <TextField
+                    fullWidth
+                    label="Nội dung *"
+                    value={formData.content}
+                    onChange={handleInputChange("content")}
+                    multiline
+                    rows={8}
+                    error={!!error && error.includes("content")}
+                    helperText="Nội dung chi tiết của bài học"
+                  />
+
+                  <Box>
+                    <Typography variant="body2" sx={{ mb: 2 }}>
+                      Thời lượng: {formData.durationInMinutes} phút
+                    </Typography>
+                    <Slider
+                      value={formData.durationInMinutes}
+                      onChange={handleDurationChange}
+                      min={5}
+                      max={180}
+                      step={5}
+                      marks={[
+                        { value: 5, label: "5min" },
+                        { value: 30, label: "30min" },
+                        { value: 60, label: "1h" },
+                        { value: 120, label: "2h" },
+                        { value: 180, label: "3h" },
+                      ]}
+                      valueLabelDisplay="auto"
+                    />
+                  </Box>
+
+                  <TextField
+                    fullWidth
+                    type="number"
+                    label="Thứ tự trong khóa học *"
+                    value={formData.order}
+                    onChange={handleInputChange("order")}
+                    inputProps={{ min: 1 }}
+                    helperText="Vị trí của bài học trong khóa học"
+                  />
+                </Stack>
+              </Grid>
+
+              <Grid item xs={12} md={4}>
+                <Typography variant="h6" sx={{ mb: 3 }}>
+                  Thông tin khóa học
+                </Typography>
+                
+                {selectedCourse && (
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="h6" sx={{ mb: 1 }}>
+                        {selectedCourse.title}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                        {selectedCourse.description}
+                      </Typography>
+                      <Typography variant="body2">
+                        <strong>Số bài học:</strong> {selectedCourse.lessonsCount || 0}
+                      </Typography>
+                      <Typography variant="body2">
+                        <strong>Học viên:</strong> {selectedCourse.enrollmentsCount || 0}
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                )}
+
+                <Card variant="outlined" sx={{ mt: 3 }}>
+                  <CardContent>
+                    <Typography variant="h6" sx={{ mb: 2 }}>
+                      Xem trước
+                    </Typography>
+                    <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+                      {formData.title || "Tên bài học"}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      Thời lượng: {formData.durationInMinutes} phút
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                      Thứ tự: {formData.order}
+                    </Typography>
+                    <Typography variant="body2">
+                      {formData.content ? 
+                        (formData.content.length > 150 
+                          ? `${formData.content.substring(0, 150)}...`
+                          : formData.content
+                        ) : "Nội dung bài học sẽ hiển thị ở đây"
+                      }
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
+
+            <Box sx={{ mt: 4, display: "flex", gap: 2, justifyContent: "flex-end" }}>
+              <Button variant="outlined" onClick={onBack} disabled={isLoading}>
+                Hủy
+              </Button>
+              <Button
+                type="submit"
+                variant="contained"
+                startIcon={isLoading ? <CircularProgress size={16} /> : <SaveIcon />}
+                disabled={isLoading}
+              >
+                {mode === "create" ? "Tạo bài học" : "Cập nhật"}
+              </Button>
+            </Box>
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Snackbar 
+        open={snackbar.open} 
+        autoHideDuration={4000} 
+        onClose={() => setSnackbar(s => ({ ...s, open: false }))}
+      >
+        <Alert severity={snackbar.severity} sx={{ width: "100%" }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/src/sections/admin/lesson/LessonListSection.tsx
+++ b/src/sections/admin/lesson/LessonListSection.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  IconButton,
+  Pagination,
+  Snackbar,
+  Alert,
+  Stack,
+  TextField,
+  Typography,
+  Chip,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import { useAppDispatch, useAppSelector } from "../../../redux/config";
+import { getLessons, deleteLesson } from "../../../redux/lesson/lessonSlice";
+import { getCourses } from "../../../redux/course/courseSlice";
+import { LessonResult } from "../../../common/@types/lesson";
+
+interface Props {
+  onCreateNew: (courseId: string) => void;
+  onEditLesson: (lesson: LessonResult) => void;
+  onViewDetails: (lesson: LessonResult) => void;
+}
+
+export default function LessonListSection({ onCreateNew, onEditLesson, onViewDetails }: Props) {
+  const dispatch = useAppDispatch();
+  const { data, isLoading, error } = useAppSelector((s) => s.lesson.lessons);
+  const { data: coursesData } = useAppSelector((s) => s.course.courses);
+
+  const [query, setQuery] = useState({ pageNumber: 1, pageSize: 12, searchTerm: "", courseId: "" });
+  const [confirmDelete, setConfirmDelete] = useState<LessonResult | null>(null);
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({ 
+    open: false, 
+    message: "", 
+    severity: "success" 
+  });
+
+  useEffect(() => {
+    dispatch(getLessons(query as any));
+    dispatch(getCourses({ pageSize: 100 } as any));
+  }, [dispatch, query.pageNumber, query.pageSize, query.searchTerm, query.courseId]);
+
+  const items = data?.items || [];
+  const totalPages = data?.totalPages || 1;
+  const courses = coursesData?.items || [];
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    try {
+      await dispatch(deleteLesson(confirmDelete.id)).unwrap();
+      setSnackbar({ open: true, message: "Xóa bài học thành công", severity: "success" });
+    } catch (e: any) {
+      setSnackbar({ open: true, message: e?.message || "Không thể xóa bài học", severity: "error" });
+    } finally {
+      setConfirmDelete(null);
+    }
+  };
+
+  return (
+    <Box>
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ xs: "stretch", sm: "center" }} justifyContent="space-between" sx={{ mb: 2 }}>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} sx={{ flex: 1 }}>
+          <TextField
+            size="small"
+            placeholder="Tìm kiếm bài học..."
+            value={query.searchTerm}
+            onChange={(e) => setQuery((q) => ({ ...q, searchTerm: e.target.value, pageNumber: 1 }))}
+            sx={{ maxWidth: 300 }}
+          />
+          <FormControl size="small" sx={{ minWidth: 200 }}>
+            <InputLabel>Khóa học</InputLabel>
+            <Select
+              value={query.courseId}
+              label="Khóa học"
+              onChange={(e) => setQuery((q) => ({ ...q, courseId: e.target.value, pageNumber: 1 }))}
+            >
+              <MenuItem value="">Tất cả khóa học</MenuItem>
+              {courses.map((course) => (
+                <MenuItem key={course.id} value={course.id}>
+                  {course.title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+        <Button 
+          variant="contained" 
+          startIcon={<AddIcon />} 
+          onClick={() => onCreateNew(query.courseId)}
+        >
+          Tạo bài học
+        </Button>
+      </Stack>
+
+      {isLoading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Alert severity="error">{error}</Alert>
+      ) : items.length === 0 ? (
+        <Alert severity="info">Chưa có bài học nào</Alert>
+      ) : (
+        <Grid container spacing={2}>
+          {items.map((lesson) => (
+            <Grid item xs={12} md={6} lg={4} key={lesson.id}>
+              <Card sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+                <CardContent sx={{ flex: 1 }}>
+                  <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 2 }}>
+                    <Chip
+                      label={`Bài ${lesson.order}`}
+                      size="small"
+                      color="primary"
+                      variant="outlined"
+                    />
+                    <Chip
+                      label={lesson.courseTitle || "Không xác định"}
+                      size="small"
+                      variant="outlined"
+                    />
+                  </Stack>
+                  
+                  <Typography variant="h6" sx={{ mb: 1 }}>
+                    {lesson.title}
+                  </Typography>
+                  
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    {lesson.content && lesson.content.length > 100 
+                      ? `${lesson.content.substring(0, 100)}...` 
+                      : lesson.content || "Chưa có nội dung"}
+                  </Typography>
+                  
+                  <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
+                    <AccessTimeIcon fontSize="small" color="action" />
+                    <Typography variant="body2" color="text.secondary">
+                      {lesson.durationInMinutes} phút
+                    </Typography>
+                  </Stack>
+
+                  <Stack direction="row" spacing={1}>
+                    <Button size="small" variant="outlined" startIcon={<VisibilityIcon />} onClick={() => onViewDetails(lesson)}>
+                      Chi tiết
+                    </Button>
+                    <Button size="small" variant="contained" startIcon={<EditIcon />} onClick={() => onEditLesson(lesson)}>
+                      Sửa
+                    </Button>
+                    <IconButton color="error" onClick={() => setConfirmDelete(lesson)}>
+                      <DeleteIcon />
+                    </IconButton>
+                  </Stack>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      {totalPages > 1 && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 3 }}>
+          <Pagination
+            count={totalPages}
+            page={query.pageNumber}
+            onChange={(_, p) => setQuery((q) => ({ ...q, pageNumber: p }))}
+            color="primary"
+          />
+        </Box>
+      )}
+
+      <Dialog open={!!confirmDelete} onClose={() => setConfirmDelete(null)}>
+        <DialogTitle>Xác nhận xóa</DialogTitle>
+        <DialogContent>Bạn có chắc muốn xóa bài học "{confirmDelete?.title}"?</DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDelete(null)}>Hủy</Button>
+          <Button color="error" onClick={handleDelete}>Xóa</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar open={snackbar.open} autoHideDuration={3000} onClose={() => setSnackbar((s) => ({ ...s, open: false }))}>
+        <Alert severity={snackbar.severity} sx={{ width: "100%" }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}


### PR DESCRIPTION
- Introduced new sidebar items for managing courses and lessons, including icons for each.
- Updated routing paths to include course and lesson management pages.
- Lazy-loaded new components for course and lesson management in the admin routes.